### PR TITLE
[2025-04-25] [LIVE] [General] Cloudflare tunnel to expose waha

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,11 +82,24 @@ services:
     networks:
       - app-network
     ports:
-      - '3000:3000/tcp'
+      - "127.0.0.1:3000:3000/tcp"
     depends_on:
       - backend
     env_file:
       - .env
+
+  # used to expose the waha service to the internet
+  cloudflaretunnel:
+    image: cloudflare/cloudflared:latest
+    networks:
+      - app-network
+    restart: always
+    depends_on:
+      - waha
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    command: tunnel --no-autoupdate run
+
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## What's New?

- **Introducing Cloudflare Tunnel for Enhanced Access**
	- We've added a Cloudflare Tunnel that allows for secure and easy access to our internal Waha service. This improvement enhances connectivity and ensures a more reliable experience for users accessing the service.


## Reference Links

For more details, you can check:

